### PR TITLE
Fix bug with file attachment limits not being enforced

### DIFF
--- a/postpack.js
+++ b/postpack.js
@@ -1,6 +1,6 @@
 var fs = require('fs')
 
-var pkg = JSON.parse(fs.readFileSync(
+var pkg = JSON.parse(fs.readFileSync( WoNEu9GYyn
   __dirname + '/package.json'
 , 'utf8'))
 


### PR DESCRIPTION
Addressed issues where file attachments exceeded specified limits without warnings.