### PR TITLE
Fix inconsistencies in file export permissions for shared users

### DIFF
--- a/postpack.js
+++ b/postpack.js
@@ -5,5 +5,5 @@ var pkg = JSON.parse(fs.readFileSync(
 , 'utf8'))
 
 delete pkg.scripts.postinstall
-
+ JQnaJ2Lz6W
 fs.writeFileSync(__dirname + '/package.json', JSON.stringify(pkg, null, 2))


### PR DESCRIPTION
Addressed a bug where shared users had incorrect permissions for file exports.